### PR TITLE
修改timeStamp为字符串类型

### DIFF
--- a/src/Weixin/JSAPI/Params/JSParams/Request.php
+++ b/src/Weixin/JSAPI/Params/JSParams/Request.php
@@ -24,7 +24,7 @@ class Request extends WeixinRequestBase
 	{
 		$data = array(
 			'appId'			=>	$sdk->publicParams->appID,
-			'timeStamp'		=>	time(),
+			'timeStamp'		=>	strval(time()),
 			'nonceStr'		=>	md5(mt_rand()),
 			'package'		=>	'prepay_id=' . $this->prepay_id,
 			'signType'		=>	$sdk->publicParams->sign_type,


### PR DESCRIPTION
解决iPhone下微信支付提示调用JSAPI缺少参数timeStamp的问题