### PR TITLE
取微信回调回来的xml，对hyperf做兼容处理

### DIFF
--- a/src/Weixin/Notify/Base.php
+++ b/src/Weixin/Notify/Base.php
@@ -52,6 +52,10 @@ abstract class Base extends NotifyBase
 		{
 			return XML::fromString($this->swooleRequest->rawContent());
 		}
+		if($this->swooleRequest instanceof \Hyperf\HttpServer\Contract\RequestInterface)
+		{
+			return XML::fromString((string)$this->swooleRequest->getBody()->getContents());
+		}
 		if($this->swooleRequest instanceof \Psr\Http\Message\ServerRequestInterface)
 		{
 			return XML::fromString((string)$this->swooleRequest->getBody());


### PR DESCRIPTION
线上调试时，还是取不到微信回调回来的xml，加上兼容代码后。跑起来没有问题。
因为 $this->swooleRequest->getBody()->getContents()是hyperf的方式，不确定是否对\Psr\Http\Message\ServerRequestInterface也支持，所以增加了一个if判断，只对hyperf兼容处理了一下。