### PR TITLE
解决PHP8 废弃libxml_disable_entity_loader 函数的问题

### DIFF
--- a/src/Lib/XML.php
+++ b/src/Lib/XML.php
@@ -6,6 +6,11 @@ class XML
 {
     public static function fromString($string)
     {
+        // PHP8中已经废弃
+        if (\PHP_VERSION_ID >= 80000) {
+            return (array) simplexml_load_string($string, null, \LIBXML_NOCDATA | \LIBXML_COMPACT);
+        }
+
         // 填补 php <= 5.4 的安全漏洞：https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=23_5
         // 记录旧值
         $oldValue = libxml_disable_entity_loader(true);


### PR DESCRIPTION
`libxml_disable_entity_loader`函数在PHP8中已经废弃了